### PR TITLE
Fix: Prevenir filtración de variables de entorno en el Backend (#27)

### DIFF
--- a/backend-core/.gitignore
+++ b/backend-core/.gitignore
@@ -47,3 +47,7 @@ devnotes.md
 **/.idea/
 **/_ReSharper*/
 **/*.DotSettings.user
+
+# Variables de entorno y secretos
+.env
+*.env

--- a/backend-ia/.gitignore
+++ b/backend-ia/.gitignore
@@ -24,3 +24,7 @@ pip-wheel-metadata/
 .coverage
 htmlcov/
 .cache/
+
+# Variables de entorno y secretos
+.env
+*.env


### PR DESCRIPTION
## Contexto
Este PR atiende la alerta de seguridad del Issue #27. Se ha protegido el repositorio a nivel de control de versiones para evitar futuras subidas accidentales de archivos de configuración sensibles.

## Cambios Incluidos
* **`fix(security)`:** Se actualizaron los archivos `.gitignore` en los módulos `backend-core` y `backend-ia` para excluir explícitamente cualquier archivo `.env`, `*.env` y variables de entorno del rastreo de Git.

## 🚨 ACCIÓN REQUERIDA POR EL EQUIPO DE BACKEND 🚨
@Elteclass  @AaronCasildo : La protección del repositorio ya está implementada. Sin embargo, dado que no tengo acceso a las plataformas de infraestructura/IA:
1. **DEBEN revocar inmediatamente la clave comprometida** en el proveedor correspondiente.
2. Generar una clave nueva y distribuirla de forma segura (no por código).
3. Si el archivo `backend-iaf.env` sigue existiendo en el historial remoto, se requerirá ejecutar `git filter-repo` desde el equipo de Backend para purgarlo del árbol de Git.

Closes #27