### PR TITLE
feat(backend-core): dockerizar backend-core y ajustar lectura de S3

### DIFF
--- a/backend-core/.dockerignore
+++ b/backend-core/.dockerignore
@@ -1,0 +1,11 @@
+**/bin/
+**/obj/
+**/.git/
+**/.vs/
+**/.idea/
+**/.vscode/
+**/*.user
+**/*.suo
+**/*.cache
+**/*.log
+NovaCloud.BackendCore/.env

--- a/backend-core/Dockerfile
+++ b/backend-core/Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+COPY NovaCloud.BackendCore/NovaCloud.BackendCore.csproj NovaCloud.BackendCore/
+RUN dotnet restore NovaCloud.BackendCore/NovaCloud.BackendCore.csproj
+
+COPY . .
+RUN dotnet publish NovaCloud.BackendCore/NovaCloud.BackendCore.csproj -c Release -o /app/publish --no-restore
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
+WORKDIR /app
+ENV ASPNETCORE_URLS=http://+:8080
+EXPOSE 8080
+
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "NovaCloud.BackendCore.dll"]

--- a/backend-core/NovaCloud.BackendCore/Controllers/FilesController.cs
+++ b/backend-core/NovaCloud.BackendCore/Controllers/FilesController.cs
@@ -1,3 +1,6 @@
+using Amazon;
+using Amazon.S3;
+using Amazon.S3.Model;
 using Microsoft.AspNetCore.Mvc;
 
 namespace NovaCloud.BackendCore.Controllers;
@@ -6,27 +9,51 @@ namespace NovaCloud.BackendCore.Controllers;
 [Route("api/[controller]")]
 public class FilesController : ControllerBase
 {
-    [HttpGet]
-    public IActionResult GetFiles()
+    private readonly string? _bucketName;
+    private readonly RegionEndpoint? _region;
+
+    public FilesController(IConfiguration configuration)
     {
-        var files = new[]
+        _bucketName = configuration["AWS:BucketName"];
+        var regionName = configuration["AWS:Region"];
+        _region = string.IsNullOrWhiteSpace(regionName)
+            ? null
+            : RegionEndpoint.GetBySystemName(regionName);
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetFiles(CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(_bucketName) || _region is null)
         {
-            new
-            {
-                name = "reporte-financiero.pdf",
-                size = "2.4MB",
-                type = "pdf",
-                uploadDate = "2026-04-03T10:00:00Z"
-            },
-            new
-            {
-                name = "logo-auratech.png",
-                size = "1.1MB",
-                type = "image",
-                uploadDate = "2026-04-03T11:30:00Z"
-            }
+            return BadRequest("Missing AWS configuration. Ensure AWS__BucketName and AWS__Region are set.");
+        }
+
+        using var s3 = new AmazonS3Client(_region);
+        var request = new ListObjectsV2Request
+        {
+            BucketName = _bucketName
         };
 
+        var response = await s3.ListObjectsV2Async(request, cancellationToken);
+        var files = response.S3Objects.Select(obj => new
+        {
+            name = obj.Key,
+            sizeBytes = obj.Size,
+            type = GetFileType(obj.Key),
+            uploadDate = obj.LastModified.HasValue
+                ? obj.LastModified.Value.ToUniversalTime().ToString("O")
+                : null
+        });
+
         return Ok(files);
+    }
+
+    private static string GetFileType(string key)
+    {
+        var extension = Path.GetExtension(key);
+        return string.IsNullOrWhiteSpace(extension)
+            ? "unknown"
+            : extension.TrimStart('.').ToLowerInvariant();
     }
 }

--- a/backend-core/readme.md
+++ b/backend-core/readme.md
@@ -1,6 +1,6 @@
 # Backend Core - Estado para el Equipo
 
-Ultima actualizacion: 2026-04-20
+Ultima actualizacion: 2026-05-11
 
 ## Alcance
 Esta carpeta registra el setup de backend-core para la arquitectura base serverless.
@@ -98,20 +98,19 @@ Endpoint de prueba:
 Resultado esperado:
 - `200 OK` con 2 objetos mock requeridos por frontend.
 
-## Evidencia por Adjuntar en PR/Issue
-1. Evidencia de respuesta de `/api/files` (`200 OK` + payload mock requerido).
-2. Nota de que `/api/files` es endpoint mock temporal en esta fase.
+## Como Ejecutar con Docker
 
-## Checklist Rapido de PR
-- [x] .NET SDK verificado
-- [x] AWS CLI verificado
-- [x] Web API inicial creada
-- [x] Paquetes AWS SDK instalados
-- [x] `GET /api/files` mock implementado
-- [x] CORS para frontend habilitado en API
-- [x] Flujo de configuracion local seguro (`.env` + reglas de ignore)
-- [x] IDs de Cognito documentados para handoff
-- [x] Evidencia de CORS en S3 adjunta
+Desde la raiz del repo (docker-compose.yml):
 
-## Estado Actual
-Los requerimientos de backend-core asignados en este issue estan completados.
+```powershell
+docker compose up --build
+```
+
+Endpoint de prueba:
+- `http://localhost:8080/api/files`
+
+Notas:
+- El contenedor usa el perfil AWS local montado desde `~/.aws` y `AWS_PROFILE=default` (ver docker-compose.yml).
+- Si quieres usar otro perfil, cambia `AWS_PROFILE` en docker-compose.yml (ej: `AWS_PROFILE=personal`).
+- La configuracion de la app (`AWS__Region`, `AWS__BucketName`, etc.) se lee desde `backend-core/NovaCloud.BackendCore/.env`.
+- Sin ambos de estos parámetros declarados no es posible hacer uso del servicio backend-core

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  backend-core:
+    build:
+      context: ./backend-core
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    env_file:
+      - ./backend-core/NovaCloud.BackendCore/.env
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      AWS_PROFILE: default
+    volumes:
+      - ${USERPROFILE}/.aws:/root/.aws:ro


### PR DESCRIPTION
## Resumen
- dockerizar backend-core con Dockerfile y docker-compose
- documentar el flujo de ejecucion con Docker
- actualizar el endpoint /api/files para leer objetos desde S3

## Cambios principales
- agregar Dockerfile y .dockerignore para backend-core
- agregar docker-compose.yml con perfil AWS montado y variables de entorno
- actualizar la documentacion de ejecucion con Docker
- listar archivos en S3 con metadata basica (nombre, tipo, fecha)

## Pruebas
- docker compose up --build
- GET http://localhost:8080/api/files

<img width="461" height="265" alt="image" src="https://github.com/user-attachments/assets/214da46b-c427-49cf-a9f5-19ca92630590" />
