### PR TITLE
feat(backend auth): integrar autenticacion con cognito y jwt

### DIFF
--- a/backend-core/NovaCloud.BackendCore/Controllers/AuthController.cs
+++ b/backend-core/NovaCloud.BackendCore/Controllers/AuthController.cs
@@ -1,0 +1,125 @@
+using Amazon.CognitoIdentityProvider;
+using Amazon.CognitoIdentityProvider.Model;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using NovaCloud.BackendCore.DTOs.Auth;
+using NovaCloud.BackendCore.Services;
+using ChangePasswordRequestDto = NovaCloud.BackendCore.DTOs.Auth.ChangePasswordRequest;
+
+namespace NovaCloud.BackendCore.Controllers;
+
+[ApiController]
+[Route("api/auth")]
+public sealed class AuthController : ControllerBase
+{
+    private readonly IAuthService _authService;
+
+    public AuthController(IAuthService authService)
+    {
+        _authService = authService;
+    }
+
+    [HttpPost("login")]
+    public async Task<IActionResult> Login([FromBody] LoginRequest request)
+    {
+        try
+        {
+            var response = await _authService.LoginAsync(request);
+            return Ok(response);
+        }
+        catch (NotAuthorizedException)
+        {
+            return Unauthorized();
+        }
+        catch (UserNotConfirmedException)
+        {
+            return Unauthorized("User not confirmed.");
+        }
+        catch (AmazonCognitoIdentityProviderException)
+        {
+            return Unauthorized();
+        }
+    }
+
+    [HttpPost("change-password")]
+    public async Task<IActionResult> ChangePassword([FromBody] ChangePasswordRequestDto request)
+    {
+        try
+        {
+            var response = await _authService.ChangePasswordAsync(request);
+            return Ok(response);
+        }
+        catch (NotAuthorizedException)
+        {
+            return Unauthorized();
+        }
+        catch (AmazonCognitoIdentityProviderException)
+        {
+            return Unauthorized();
+        }
+        catch (InvalidOperationException)
+        {
+            return StatusCode(StatusCodes.Status500InternalServerError, "Password change failed.");
+        }
+    }
+
+    [HttpPost("refresh")]
+    public async Task<IActionResult> Refresh([FromBody] RefreshTokenRequest request)
+    {
+        try
+        {
+            var response = await _authService.RefreshTokenAsync(request);
+            return Ok(response);
+        }
+        catch (NotAuthorizedException)
+        {
+            return Unauthorized();
+        }
+        catch (AmazonCognitoIdentityProviderException)
+        {
+            return Unauthorized();
+        }
+        catch (InvalidOperationException)
+        {
+            return StatusCode(StatusCodes.Status500InternalServerError, "Token refresh failed.");
+        }
+    }
+
+    [Authorize]
+    [HttpPost("logout")]
+    public async Task<IActionResult> Logout()
+    {
+        var token = GetBearerToken(Request.Headers.Authorization);
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return BadRequest("Missing bearer token.");
+        }
+
+        await _authService.LogoutAsync(token);
+        return NoContent();
+    }
+
+    [Authorize]
+    [HttpGet("me")]
+    public ActionResult<MeResponse> Me()
+    {
+        var response = _authService.GetMe(User);
+        return Ok(response);
+    }
+
+    private static string? GetBearerToken(string? authorizationHeader)
+    {
+        if (string.IsNullOrWhiteSpace(authorizationHeader))
+        {
+            return null;
+        }
+
+        const string prefix = "Bearer ";
+        if (!authorizationHeader.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return authorizationHeader[prefix.Length..].Trim();
+    }
+}

--- a/backend-core/NovaCloud.BackendCore/DTOs/Auth/ChangePasswordRequest.cs
+++ b/backend-core/NovaCloud.BackendCore/DTOs/Auth/ChangePasswordRequest.cs
@@ -1,0 +1,8 @@
+namespace NovaCloud.BackendCore.DTOs.Auth;
+
+public sealed class ChangePasswordRequest
+{
+    public string Email { get; init; } = string.Empty;
+    public string Session { get; init; } = string.Empty;
+    public string NewPassword { get; init; } = string.Empty;
+}

--- a/backend-core/NovaCloud.BackendCore/DTOs/Auth/LoginRequest.cs
+++ b/backend-core/NovaCloud.BackendCore/DTOs/Auth/LoginRequest.cs
@@ -1,0 +1,7 @@
+namespace NovaCloud.BackendCore.DTOs.Auth;
+
+public sealed class LoginRequest
+{
+    public string Email { get; init; } = string.Empty;
+    public string Password { get; init; } = string.Empty;
+}

--- a/backend-core/NovaCloud.BackendCore/DTOs/Auth/LoginResponse.cs
+++ b/backend-core/NovaCloud.BackendCore/DTOs/Auth/LoginResponse.cs
@@ -1,0 +1,10 @@
+namespace NovaCloud.BackendCore.DTOs.Auth;
+
+public sealed class LoginResponse
+{
+    public string? Token { get; init; }
+    public string? RefreshToken { get; init; }
+    public string? Role { get; init; }
+    public string? Email { get; init; }
+    public string? Session { get; init; }
+}

--- a/backend-core/NovaCloud.BackendCore/DTOs/Auth/MeResponse.cs
+++ b/backend-core/NovaCloud.BackendCore/DTOs/Auth/MeResponse.cs
@@ -1,0 +1,8 @@
+namespace NovaCloud.BackendCore.DTOs.Auth;
+
+public sealed class MeResponse
+{
+    public string Email { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string Role { get; init; } = string.Empty;
+}

--- a/backend-core/NovaCloud.BackendCore/DTOs/Auth/RefreshTokenRequest.cs
+++ b/backend-core/NovaCloud.BackendCore/DTOs/Auth/RefreshTokenRequest.cs
@@ -1,0 +1,7 @@
+namespace NovaCloud.BackendCore.DTOs.Auth;
+
+public sealed class RefreshTokenRequest
+{
+    public string Email { get; init; } = string.Empty;
+    public string RefreshToken { get; init; } = string.Empty;
+}

--- a/backend-core/NovaCloud.BackendCore/NovaCloud.BackendCore.csproj
+++ b/backend-core/NovaCloud.BackendCore/NovaCloud.BackendCore.csproj
@@ -7,9 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Amazon.Extensions.CognitoAuthentication" Version="2.0.4" />
     <PackageReference Include="AWSSDK.CognitoIdentityProvider" Version="4.0.7" />
     <PackageReference Include="AWSSDK.S3" Version="4.0.21.2" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
   </ItemGroup>
 

--- a/backend-core/NovaCloud.BackendCore/Program.cs
+++ b/backend-core/NovaCloud.BackendCore/Program.cs
@@ -1,10 +1,49 @@
+using Amazon;
+using Amazon.CognitoIdentityProvider;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using NovaCloud.BackendCore.Services;
+
 DotNetEnv.Env.Load();
 
 var builder = WebApplication.CreateBuilder(args);
 
+var awsRegion = builder.Configuration["AWS:Region"];
+var userPoolId = builder.Configuration["AWS:UserPoolId"];
+var clientId = builder.Configuration["AWS:ClientId"];
+
+if (string.IsNullOrWhiteSpace(awsRegion) ||
+    string.IsNullOrWhiteSpace(userPoolId) ||
+    string.IsNullOrWhiteSpace(clientId))
+{
+    throw new InvalidOperationException(
+        "Missing AWS configuration. Ensure AWS__Region, AWS__UserPoolId, and AWS__ClientId are set.");
+}
+
+var regionEndpoint = RegionEndpoint.GetBySystemName(awsRegion);
+
 // Services
 builder.Services.AddOpenApi();
 builder.Services.AddControllers();
+builder.Services.AddSingleton<IAmazonCognitoIdentityProvider>(_ =>
+    new AmazonCognitoIdentityProviderClient(regionEndpoint));
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.Authority = $"https://cognito-idp.{awsRegion}.amazonaws.com/{userPoolId}";
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidIssuer = $"https://cognito-idp.{awsRegion}.amazonaws.com/{userPoolId}",
+            ValidateAudience = true,
+            ValidAudience = clientId,
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true
+        };
+    });
+    
+builder.Services.AddAuthorization();
+builder.Services.AddScoped<IAuthService, AuthService>();
 builder.Services.AddCors(options =>
 {
     options.AddPolicy("FrontendDev", policy =>
@@ -26,6 +65,8 @@ if (!app.Environment.IsDevelopment())
     app.UseHttpsRedirection();
 }
 app.UseCors("FrontendDev");
+app.UseAuthentication();
+app.UseAuthorization();
 app.MapControllers();
 
 app.Run();

--- a/backend-core/NovaCloud.BackendCore/Services/AuthService.cs
+++ b/backend-core/NovaCloud.BackendCore/Services/AuthService.cs
@@ -1,0 +1,236 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text.Json;
+using Amazon.CognitoIdentityProvider;
+using Amazon.CognitoIdentityProvider.Model;
+using NovaCloud.BackendCore.DTOs.Auth;
+using ChangePasswordRequestDto = NovaCloud.BackendCore.DTOs.Auth.ChangePasswordRequest;
+
+namespace NovaCloud.BackendCore.Services;
+
+public sealed class AuthService : IAuthService
+{
+    private readonly IAmazonCognitoIdentityProvider _cognito;
+    private readonly string _clientId;
+
+    public AuthService(IAmazonCognitoIdentityProvider cognito, IConfiguration configuration)
+    {
+        _cognito = cognito;
+        _clientId = configuration["AWS:ClientId"]
+            ?? throw new InvalidOperationException("Missing AWS:ClientId configuration.");
+    }
+
+    public async Task<LoginResponse> LoginAsync(LoginRequest request)
+    {
+        var authRequest = new InitiateAuthRequest
+        {
+            AuthFlow = AuthFlowType.USER_PASSWORD_AUTH,
+            ClientId = _clientId,
+            AuthParameters = new Dictionary<string, string>
+            {
+                ["USERNAME"] = request.Email,
+                ["PASSWORD"] = request.Password
+            }
+        };
+
+        var response = await _cognito.InitiateAuthAsync(authRequest);
+
+        if (response.ChallengeName == ChallengeNameType.NEW_PASSWORD_REQUIRED)
+        {
+            return new LoginResponse
+            {
+                Email = request.Email,
+                Session = response.Session,
+                Token = null,
+                RefreshToken = null,
+                Role = null
+            };
+        }
+
+        var result = response.AuthenticationResult;
+        if (result is null)
+        {
+            throw new InvalidOperationException("Authentication failed without a result.");
+        }
+
+        var role = GetRoleFromIdToken(result.IdToken);
+        var email = GetEmailFromIdToken(result.IdToken) ?? request.Email;
+
+        return new LoginResponse
+        {
+            Token = result.IdToken,
+            RefreshToken = result.RefreshToken,
+            Role = role,
+            Email = email
+        };
+    }
+
+    public async Task<LoginResponse> ChangePasswordAsync(ChangePasswordRequestDto request)
+    {
+        var challengeRequest = new RespondToAuthChallengeRequest
+        {
+            ClientId = _clientId,
+            ChallengeName = ChallengeNameType.NEW_PASSWORD_REQUIRED,
+            Session = request.Session,
+            ChallengeResponses = new Dictionary<string, string>
+            {
+                ["USERNAME"] = request.Email,
+                ["NEW_PASSWORD"] = request.NewPassword
+            }
+        };
+
+        var response = await _cognito.RespondToAuthChallengeAsync(challengeRequest);
+        var result = response.AuthenticationResult;
+        if (result is null)
+        {
+            throw new InvalidOperationException("Password change failed without a result.");
+        }
+
+        var role = GetRoleFromIdToken(result.IdToken);
+        var email = GetEmailFromIdToken(result.IdToken) ?? request.Email;
+
+        return new LoginResponse
+        {
+            Token = result.IdToken,
+            RefreshToken = result.RefreshToken,
+            Role = role,
+            Email = email
+        };
+    }
+
+    public async Task<LoginResponse> RefreshTokenAsync(RefreshTokenRequest request)
+    {
+        var authRequest = new InitiateAuthRequest
+        {
+            AuthFlow = AuthFlowType.REFRESH_TOKEN_AUTH,
+            ClientId = _clientId,
+            AuthParameters = new Dictionary<string, string>
+            {
+                ["REFRESH_TOKEN"] = request.RefreshToken
+            }
+        };
+
+        var response = await _cognito.InitiateAuthAsync(authRequest);
+        var result = response.AuthenticationResult;
+        if (result is null)
+        {
+            throw new InvalidOperationException("Token refresh failed without a result.");
+        }
+
+        var role = GetRoleFromIdToken(result.IdToken);
+        var email = GetEmailFromIdToken(result.IdToken) ?? request.Email;
+
+        return new LoginResponse
+        {
+            Token = result.IdToken,
+            RefreshToken = request.RefreshToken,
+            Role = role,
+            Email = email
+        };
+    }
+
+    public async Task LogoutAsync(string accessToken)
+    {
+        if (string.IsNullOrWhiteSpace(accessToken))
+        {
+            throw new ArgumentException("Access token is required.", nameof(accessToken));
+        }
+
+        var request = new GlobalSignOutRequest
+        {
+            AccessToken = accessToken
+        };
+
+        await _cognito.GlobalSignOutAsync(request);
+    }
+
+    public MeResponse GetMe(ClaimsPrincipal user)
+    {
+        var email = GetEmailFromClaims(user.Claims) ?? string.Empty;
+        var name = user.FindFirst("name")?.Value
+            ?? user.FindFirst(ClaimTypes.Name)?.Value
+            ?? email;
+        var role = GetRoleFromClaims(user.Claims) ?? string.Empty;
+
+        return new MeResponse
+        {
+            Email = email,
+            Name = name,
+            Role = role
+        };
+    }
+
+    private static string? GetRoleFromIdToken(string? idToken)
+    {
+        var claims = GetClaimsFromIdToken(idToken);
+        return GetRoleFromClaims(claims);
+    }
+
+    private static string? GetEmailFromIdToken(string? idToken)
+    {
+        var claims = GetClaimsFromIdToken(idToken);
+        return GetEmailFromClaims(claims);
+    }
+
+    private static IEnumerable<Claim> GetClaimsFromIdToken(string? idToken)
+    {
+        if (string.IsNullOrWhiteSpace(idToken))
+        {
+            return Array.Empty<Claim>();
+        }
+
+        var handler = new JwtSecurityTokenHandler();
+        var token = handler.ReadJwtToken(idToken);
+        return token.Claims;
+    }
+
+    private static string? GetRoleFromClaims(IEnumerable<Claim> claims)
+    {
+        foreach (var claim in claims.Where(c => c.Type == "cognito:groups"))
+        {
+            var role = TryReadGroupValue(claim.Value);
+            if (!string.IsNullOrWhiteSpace(role))
+            {
+                return role;
+            }
+        }
+
+        return null;
+    }
+
+    private static string? GetEmailFromClaims(IEnumerable<Claim> claims)
+    {
+        return claims.FirstOrDefault(c => c.Type == "email")?.Value
+            ?? claims.FirstOrDefault(c => c.Type == ClaimTypes.Email)?.Value;
+    }
+
+    private static string? TryReadGroupValue(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var trimmed = value.Trim();
+        if (!trimmed.StartsWith("[", StringComparison.Ordinal))
+        {
+            return trimmed;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(trimmed);
+            if (doc.RootElement.ValueKind == JsonValueKind.Array &&
+                doc.RootElement.GetArrayLength() > 0)
+            {
+                return doc.RootElement[0].GetString();
+            }
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+
+        return null;
+    }
+}

--- a/backend-core/NovaCloud.BackendCore/Services/IAuthService.cs
+++ b/backend-core/NovaCloud.BackendCore/Services/IAuthService.cs
@@ -1,0 +1,13 @@
+using System.Security.Claims;
+using NovaCloud.BackendCore.DTOs.Auth;
+
+namespace NovaCloud.BackendCore.Services;
+
+public interface IAuthService
+{
+    Task<LoginResponse> LoginAsync(LoginRequest request);
+    Task<LoginResponse> ChangePasswordAsync(ChangePasswordRequest request);
+    Task<LoginResponse> RefreshTokenAsync(RefreshTokenRequest request);
+    Task LogoutAsync(string accessToken);
+    MeResponse GetMe(ClaimsPrincipal user);
+}


### PR DESCRIPTION
## Resumen
- integrar autenticacion con AWS Cognito via JWT bearer y validacion por issuer/audience
- habilitar flujos USER_PASSWORD_AUTH, NEW_PASSWORD_REQUIRED y REFRESH_TOKEN_AUTH
- estandarizar contratos DTO para auth y separar logica de SDK en un servicio dedicado

## Cambios por carpeta

- Services/
  - agregar AuthService con llamadas a Cognito (InitiateAuth, RespondToAuthChallenge, GlobalSignOut)
  - agregar IAuthService para aislar la logica del controlador

- Controllers/
  - agregar AuthController con endpoints /api/auth/* y manejo de errores Cognito

- DTOs/Auth/
  - agregar LoginRequest, LoginResponse, ChangePasswordRequest, RefreshTokenRequest, MeResponse

## Cambios tecnicos
- configurar autenticacion JwtBearer con authority de Cognito y validacion de issuer/audience
- inyectar AmazonCognitoIdentityProviderClient como singleton
- agregar AddAuthorization y middleware UseAuthentication/UseAuthorization

## Como funciona
- login ejecuta USER_PASSWORD_AUTH; si Cognito devuelve NEW_PASSWORD_REQUIRED, se entrega Session para completar el cambio de password
- change-password responde el challenge y retorna tokens finales
- refresh ejecuta REFRESH_TOKEN_AUTH y retorna nuevo IdToken
- logout invalida sesiones con GlobalSignOut (AccessToken)
- me retorna email, name y rol desde claims (cognito:groups)